### PR TITLE
feat: Remove defaults for BOM column names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,9 @@ inputs:
     default: "1,10,100,1000"
   bom_part_number_column:
     description: >
-      The name of the part number column in the BOM file. Defaults to 'Part
-      Number'.
-    default: Part Number
+      The name of the part number column in the BOM file.  You must provide
+      this.
+    default: ''
   bom_manufacturer_column:
     description: >
       The name of the manufacturer column in the BOM file.  Defaults to ''.  If
@@ -22,8 +22,8 @@ inputs:
     default: ''
   bom_quantity_column:
     description: >
-      The name of the quantity column in the BOM file. Defaults to 'Quantity'.
-    default: Quantity
+      The name of the quantity column in the BOM file.  You must provide this.
+    default: ''
   search_strategy:
     description: >
       The Cofactr search strategy. Can be: "mpn_sku_mfr" or "fuzzy" (uses mpn).

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -68,12 +68,16 @@ def main() -> None:
 
     part_number_column = args.bom_part_number_column
     if not part_number_column:
-        raise ValueError("BOM part number column needs to be specified.")
+        raise ValueError(
+            "BOM part number column needs to be specified.  Please set bom_part_number_column."
+        )
 
     manufacturer_column = args.bom_manufacturer_column
     quantity_column = args.bom_quantity_column
     if not quantity_column:
-        raise ValueError("BOM quantity column needs to be specified.")
+        raise ValueError(
+            "BOM quantity column needs to be specified.  Please set bom_quantity_column."
+        )
 
     search_strategy = SearchStrategy(args.search_strategy)
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -31,8 +31,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--bom-part-number-column",
-        help="The name of the part number column in the BOM file. Defaults to '%(default)s'.",
-        default="Part Number",
+        help="The name of the part number column in the BOM file.  You must provide this.",
+        default="",
     )
     parser.add_argument(
         "--bom-manufacturer-column",
@@ -42,8 +42,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--bom-quantity-column",
-        help="The name of the quantity column in the BOM file. Defaults to '%(default)s'.",
-        default="Quantity",
+        help="The name of the quantity column in the BOM file.  You must provide this.",
+        default="",
     )
     parser.add_argument(
         "--search-strategy",
@@ -67,8 +67,14 @@ def main() -> None:
     quantities = [int(quantity) for quantity in args.quantities.split(",")]
 
     part_number_column = args.bom_part_number_column
+    if not part_number_column:
+        raise ValueError("BOM part number column needs to be specified.")
+
     manufacturer_column = args.bom_manufacturer_column
     quantity_column = args.bom_quantity_column
+    if not quantity_column:
+        raise ValueError("BOM quantity column needs to be specified.")
+
     search_strategy = SearchStrategy(args.search_strategy)
 
     with open(args.bom_file, "r") as bom_file:


### PR DESCRIPTION
Removes the default values for BOM column names. Now they're required. The hypothesis is that everyone's BOM will be different, and having a default will only be confusing.

Stacked on #6.