### PR TITLE
ci: Fix to update type stubs and package together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      requests-dependencies:
+        patterns:
+          - "types-requests"
+          - "requests"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This will make Dependabot update the package and its types together.